### PR TITLE
Replace work ecosystem list with intro-style paragraph

### DIFF
--- a/content/work/_index.md
+++ b/content/work/_index.md
@@ -16,6 +16,13 @@ punchline: "Il y a toujours une histoire à raconter."
 
 bio: "Je suis réalisateur et photographe. Je documente des aventures, des savoir-faire, des territoires...<br>Basé en Finistère Nord, je vais chercher les histoires partout où elles m'attendent."
 
+ecosystem_text: >
+  Ce que vous voyez ici est une petite sélection.
+  Le reste se trouve chez <a href="https://captainyvon.fr" target="_blank" rel="noopener noreferrer">Captain Yvon Studio</a>,
+  mon studio de production, et
+  <a href="https://aunord.fr" target="_blank" rel="noopener noreferrer">Aunord</a>,
+  le collectif que j'ai rejoint en Finistère Nord.
+
 signature: "Un projet à raconter ? [hello@gregorymignard.com](mailto:hello@gregorymignard.com)"
 
 # ─────────────────────────────────────────────────────────────────────

--- a/content/work/_index.md
+++ b/content/work/_index.md
@@ -79,23 +79,6 @@ projects:
     alt: "Ferðamenn — zine photographique de Grégory Mignard et Yves Quéré sur un voyage en Islande"
     variant: "right"
 
-# ─────────────────────────────────────────────────────────────────────
-# Bloc Écosystème
-# ─────────────────────────────────────────────────────────────────────
-
-ecosystem:
-  - name: "Captain Yvon Studio"
-    url: "https://captainyvon.fr"
-    caption: "Mon studio de production, avec Jeremy Janin"
-
-  - name: "AuNord"
-    url: "https://aunord.fr"
-    caption: "Le collectif que j'ai rejoint en Finistère Nord"
-
-  - name: "1% for the Planet"
-    url: "https://www.onepercentfortheplanet.fr"
-    caption: "Membre depuis 2022"
-
 resources:
 - src: "cover.webp"
   name: "cover"

--- a/themes/less/assets/css/work.scss
+++ b/themes/less/assets/css/work.scss
@@ -108,12 +108,23 @@
 
 .work-project-media {
   margin-bottom: 1.25rem;
+
+  a {
+    display: block;
+    border-bottom: none;
+
+    &:hover img {
+      opacity: 0.92;
+    }
+  }
+
   img {
     display: block;
     width: 100%;
     height: auto;
     aspect-ratio: 16 / 9;
     object-fit: cover;
+    transition: opacity 0.2s ease;
   }
 }
 

--- a/themes/less/assets/css/work.scss
+++ b/themes/less/assets/css/work.scss
@@ -104,6 +104,10 @@
   @media (min-width: 812px) {
     margin-bottom: 6rem;
   }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .work-project-media {

--- a/themes/less/assets/css/work.scss
+++ b/themes/less/assets/css/work.scss
@@ -190,77 +190,9 @@
   }
 }
 
-/* --- 7. Bloc Écosystème (format identique à /essentiels/) --------------- */
+/* --- 7. Bloc Écosystème ------------------------------------------------- */
 .work-ecosystem {
   padding: 0.5rem 0 1rem;
-}
-
-.work-ecosystem-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  li {
-    font-family: var(--sans-serif-font);
-    font-size: 0.9rem;
-
-    /* Mobile: empilé */
-    @media (max-width: 767px) {
-      display: block;
-      padding: 0.75rem 0;
-      border-bottom: 1px solid rgba(0,0,0,0.1);
-
-      &:last-child { border-bottom: none; }
-
-      strong {
-        display: block;
-        font-weight: 600;
-        margin-bottom: 0.25rem;
-        a { border-bottom: none; }
-      }
-
-      em {
-        display: block;
-        font-style: normal;
-        opacity: 0.6;
-        font-size: 0.85rem;
-      }
-    }
-
-    /* Desktop: ligne avec points de suite */
-    @media (min-width: 768px) {
-      display: flex;
-      align-items: baseline;
-      padding: 0.35rem 0;
-
-      strong {
-        font-weight: 500;
-        flex-shrink: 0;
-        order: 1;
-        a { border-bottom: none; }
-      }
-
-      &::before {
-        content: "";
-        flex-grow: 1;
-        border-bottom: 1px dotted rgba(0,0,0,0.3);
-        margin: 0 0.5rem;
-        min-width: 1rem;
-        order: 2;
-      }
-
-      em {
-        flex-shrink: 0;
-        font-style: normal;
-        opacity: 0.6;
-        order: 3;
-      }
-    }
-
-    a {
-      border-bottom: none;
-    }
-  }
 }
 
 /* --- 8. Signature de fin ------------------------------------------------ */

--- a/themes/less/layouts/_default/work.html
+++ b/themes/less/layouts/_default/work.html
@@ -35,7 +35,13 @@
     {{ if eq .variant "right" }}{{ $classes = "work-project--split work-project--right" }}{{ end }}
     <article class="work-project {{ $classes }}">
       <div class="work-project-media">
-        {{ with $page.Resources.GetMatch .image }}<img src="{{ .RelPermalink }}" alt="{{ $project.alt }}" loading="lazy">{{ end }}
+        {{ with $page.Resources.GetMatch .image }}
+          {{ if $project.link_url }}
+            <a href="{{ $project.link_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ $project.title }}"><img src="{{ .RelPermalink }}" alt="{{ $project.alt }}" loading="lazy"></a>
+          {{ else }}
+            <img src="{{ .RelPermalink }}" alt="{{ $project.alt }}" loading="lazy">
+          {{ end }}
+        {{ end }}
       </div>
       <div class="work-project-body">
         <h2 class="work-project-title">{{ .title }}</h2>
@@ -57,7 +63,7 @@
 
 {{/* 7. Bloc Écosystème */}}
 <section class="work-ecosystem mx-8 md:mx-auto" style="max-width: 825px;">
-  <p class="work-bio">Ce que vous voyez ici est une sélection. Le reste se trouve chez <a href="https://captainyvon.fr" target="_blank" rel="noopener noreferrer">Captain Yvon Studio</a>, mon studio avec Jeremy, et <a href="https://aunord.fr" target="_blank" rel="noopener noreferrer">AuNord</a>, le collectif que j'ai rejoint en Finistère Nord.</p>
+  <p class="work-bio">{{ .Params.ecosystem_text | safeHTML }}</p>
 </section>
 
 {{/* Vague séparatrice */}}

--- a/themes/less/layouts/_default/work.html
+++ b/themes/less/layouts/_default/work.html
@@ -57,14 +57,7 @@
 
 {{/* 7. Bloc Écosystème */}}
 <section class="work-ecosystem mx-8 md:mx-auto" style="max-width: 825px;">
-  <ul class="work-ecosystem-list">
-    {{ range .Params.ecosystem }}
-      <li>
-        <strong><a href="{{ .url }}" target="_blank" rel="noopener noreferrer">{{ .name }}</a></strong>
-        <em>{{ .caption }}</em>
-      </li>
-    {{ end }}
-  </ul>
+  <p class="work-bio">Ce que vous voyez ici est une sélection. Le reste se trouve chez <a href="https://captainyvon.fr" target="_blank" rel="noopener noreferrer">Captain Yvon Studio</a>, mon studio avec Jeremy, et <a href="https://aunord.fr" target="_blank" rel="noopener noreferrer">AuNord</a>, le collectif que j'ai rejoint en Finistère Nord.</p>
 </section>
 
 {{/* Vague séparatrice */}}


### PR DESCRIPTION
Drop the dotted-leader affiliations list (and the "1% for the Planet" entry) on /work in favor of a single paragraph using the same work-bio class as the page intro, with inline links to Captain Yvon Studio and AuNord.

https://claude.ai/code/session_017VfaX6sYCoimAKz1Exbhaj